### PR TITLE
Update SecTalks Canberra Description

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Meetups by Region
 | Meetup Name 	| Typically on 	| About this Meetup | Locale 	|
 |-------------	|--------------	|-----------	|-------------------	|
 |[CSides](https://bsidescbr.com.au/csides.html)	| 3rd Friday, Monthly 	| CSides Monthly Security Meetups provide an opportunity to listen to and share security research within the Canberra region. The meeting occurs normally on the 3rd Friday of every month. Each meetup consists of 1-2 talks of around 30 mins each. Talks start at 6pm and are followed by some socialising at a local pub. New attendees are welcome, just come along! (There are no entry fees, and no tickets to book) The talks at CSides are technical. CSides welcomes new and interesting speakers to present - the topic will be on a technical or security issue.	| Acton, Canberra	|
-| [SecTalks Canberra](https://www.sectalks.org/canberra/)  |  2nd Tuesday, Monthly	| SecTalks Melbourne is a non-profit session for technical security talks, and hands-on challenges. A forum to discuss technical (in)security stuff and share our thoughts. | CBD, Canberra. |
+| [SecTalks Canberra](https://www.sectalks.org/canberra/)  |  2nd Tuesday, Monthly	| SecTalks Melbourne is a non-profit session for technical security talks, and hands-on challenges. A forum to discuss technical (in)security stuff and share our thoughts. Typically a presentation and a technical workshop. Runs from 7.00 until 9.00(ish).
+Locale: Canberra CBD |
 |             	|              	|           	|                   	|
 
 #### Western Australia


### PR DESCRIPTION
Updating SecTalks Canberra description per request from syngularity0 (and also because it was showing a Melbourne description).